### PR TITLE
Allow remote eggs and any required option on cli

### DIFF
--- a/scrapyd-client/scrapyd-deploy
+++ b/scrapyd-client/scrapyd-deploy
@@ -48,8 +48,9 @@ def parse_opts():
         help="debug mode (do not remove build dir)")
     parser.add_option("-L", "--list-projects", metavar="TARGET", \
         help="list available projects on TARGET")
-    parser.add_option("--egg", metavar="FILE",
-        help="use the given egg, instead of building it")
+    parser.add_option("--egg", metavar="FILE/URL",
+        help="use and download if needed the given egg, instead of building "
+        "it")
     parser.add_option("--build-egg", metavar="FILE",
         help="only build the egg, don't deploy it")
     parser.add_option("--settings-module", metavar="SCRAPY_SETTINGS_MODULE",
@@ -100,7 +101,7 @@ def main():
             if version is None:
                 version = _get_version(target, opts)
             _build_egg_and_deploy_target(target, version, opts)
-    else: # buld egg and deploy
+    else: # buld/retrieve egg and deploy
         target_name = _get_target_name(args)
         target = _get_target(target_name, opts)
         version = _get_version(target, opts)
@@ -202,8 +203,16 @@ def _get_version(target, opts):
         return str(int(time.time()))
 
 def _upload_egg(target, eggpath, project, version):
-    with open(eggpath, 'rb') as f:
+    if eggpath.startswith('http'):
+        eggdata = urllib2.Request
+        req = urllib2.Request(eggpath)
+        f = urllib2.urlopen(req)
         eggdata = f.read()
+
+    else:
+        with open(eggpath, 'rb') as f:
+            eggdata = f.read()
+
     data = {
         'project': project,
         'version': version,

--- a/scrapyd-client/scrapyd-deploy
+++ b/scrapyd-client/scrapyd-deploy
@@ -52,24 +52,35 @@ def parse_opts():
         help="use the given egg, instead of building it")
     parser.add_option("--build-egg", metavar="FILE",
         help="only build the egg, don't deploy it")
+    parser.add_option("--settings-module", metavar="SCRAPY_SETTINGS_MODULE",
+        help="python module to load as scrapy settings, can be passed also "
+        "through the env var SCRAPY_SETTINGS_MODULE")
+    parser.add_option("--url", metavar="SCRAPYD_URL",
+        help="URL to the scrapyd server, overrides the url definition in the "
+        "target if any")
     return parser.parse_args()
 
 def main():
     opts, args = parse_opts()
     exitcode = 0
+    if opts.settings_module:
+        os.environ['SCRAPY_SETTINGS_MODULE'] = opts.settings_module
+
     if not inside_project():
-        _log("Error: no Scrapy project found in this location")
+        _log("Error: no Scrapy project found in this location and no url"
+             "passed, ")
         sys.exit(1)
+
 
     urllib2.install_opener(urllib2.build_opener(HTTPRedirectHandler))
 
     if opts.list_targets:
-        for name, target in _get_targets().items():
+        for name, target in _get_targets(opts).items():
             print "%-20s %s" % (name, target['url'])
         return
 
     if opts.list_projects:
-        target = _get_target(opts.list_projects)
+        target = _get_target(opts.list_projects, opts)
         req = urllib2.Request(_url(target, 'listprojects.json'))
         _add_auth_header(req, target)
         f = urllib2.urlopen(req)
@@ -85,13 +96,13 @@ def main():
         shutil.copyfile(egg, opts.build_egg)
     elif opts.deploy_all_targets:
         version = None
-        for name, target in _get_targets().items():
+        for name, target in _get_targets(opts).items():
             if version is None:
                 version = _get_version(target, opts)
             _build_egg_and_deploy_target(target, version, opts)
     else: # buld egg and deploy
         target_name = _get_target_name(args)
-        target = _get_target(target_name)
+        target = _get_target(target_name, opts)
         version = _get_version(target, opts)
         _build_egg_and_deploy_target(target, version, opts)
 
@@ -140,12 +151,16 @@ def _get_option(section, option, default=None):
     return cfg.get(section, option) if cfg.has_option(section, option) \
         else default
 
-def _get_targets():
+def _get_targets(opts):
     cfg = get_config()
     baset = dict(cfg.items('deploy')) if cfg.has_section('deploy') else {}
     targets = {}
     if 'url' in baset:
         targets['default'] = baset
+    if opts and opts.url:
+        if 'default' not in targets:
+            targets['default'] = {}
+        targets['default']['url'] = opts.url
     for x in cfg.sections():
         if x.startswith('deploy:'):
             t = baset.copy()
@@ -153,9 +168,10 @@ def _get_targets():
             targets[x[7:]] = t
     return targets
 
-def _get_target(name):
+
+def _get_target(name='default', opts=None):
     try:
-        return _get_targets()[name]
+        return _get_targets(opts)[name]
     except KeyError:
         raise _fail("Unknown target: %s" % name)
 


### PR DESCRIPTION
* Now you can specify an http/https url in the --egg option and it
  will fetch the egg from the remote url for the deploy.
* You can also specify the settings-class and the scrapyd server url
  too, allowing you to deploy spiders without having to have the
  source code nor the egg locally