### PR TITLE
Allow download spider from pip

### DIFF
--- a/scrapyd-client/scrapyd-deploy
+++ b/scrapyd-client/scrapyd-deploy
@@ -93,7 +93,7 @@ def main():
         target_name = _get_target_name(args)
         target = _get_target(target_name)
         version = _get_version(target, opts)
-        _build_egg_and_deploy_target(target, version, opts)
+        exitcode = _build_egg_and_deploy_target(target, version, opts)
 
     if tmpdir:
         if opts.debug:
@@ -104,6 +104,7 @@ def main():
     sys.exit(exitcode)
 
 def _build_egg_and_deploy_target(target, version, opts):
+    exitcode = 0
     project = _get_project(target, opts)
     if opts.egg:
         _log("Using egg: %s" % opts.egg)
@@ -113,6 +114,7 @@ def _build_egg_and_deploy_target(target, version, opts):
         egg, tmpdir = _build_egg()
     if not _upload_egg(target, egg, project, version):
         exitcode = 1
+    return exitcode
 
 def _log(message):
     sys.stderr.write(message + os.linesep)

--- a/scrapyd-client/scrapyd-deploy
+++ b/scrapyd-client/scrapyd-deploy
@@ -93,7 +93,7 @@ def main():
         target_name = _get_target_name(args)
         target = _get_target(target_name)
         version = _get_version(target, opts)
-        exitcode = _build_egg_and_deploy_target(target, version, opts)
+        exitcode, tmpdir = _build_egg_and_deploy_target(target, version, opts)
 
     if tmpdir:
         if opts.debug:
@@ -105,6 +105,8 @@ def main():
 
 def _build_egg_and_deploy_target(target, version, opts):
     exitcode = 0
+    tmpdir = None
+
     project = _get_project(target, opts)
     if opts.egg:
         _log("Using egg: %s" % opts.egg)
@@ -114,7 +116,7 @@ def _build_egg_and_deploy_target(target, version, opts):
         egg, tmpdir = _build_egg()
     if not _upload_egg(target, egg, project, version):
         exitcode = 1
-    return exitcode
+    return exitcode, tmpdir
 
 def _log(message):
     sys.stderr.write(message + os.linesep)

--- a/scrapyd-client/scrapyd-deploy
+++ b/scrapyd-client/scrapyd-deploy
@@ -35,7 +35,7 @@ setup(
 """
 
 
-def parse_opts():
+def parse_opts(args):
     parser = OptionParser(
         usage="%prog [options] [ [target] | -l | -L <target> ]",
         description="Deploy Scrapy project to Scrapyd server")
@@ -62,11 +62,11 @@ def parse_opts():
     parser.add_option(
         "--build-egg", metavar="FILE",
         help="only build the egg, don't deploy it")
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
-def main():
-    opts, args = parse_opts()
+def main(args):
+    opts, args = parse_opts(args)
     exitcode = 0
     if not inside_project():
         _log("Error: no Scrapy project found in this location")
@@ -314,4 +314,4 @@ class HTTPRedirectHandler(urllib2.HTTPRedirectHandler):
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv[1:])

--- a/scrapyd-client/scrapyd-deploy
+++ b/scrapyd-client/scrapyd-deploy
@@ -14,7 +14,7 @@ from urlparse import urlparse, urljoin
 from subprocess import Popen, PIPE, check_call
 
 from w3lib.form import encode_multipart
-import setuptools # not used in code but needed in runtime, don't remove!
+import setuptools  # not used in code but needed in runtime, don't remove!
 
 from scrapy.utils.project import inside_project
 from scrapy.utils.http import basic_auth_header
@@ -22,7 +22,7 @@ from scrapy.utils.python import retry_on_eintr
 from scrapy.utils.conf import get_config, closest_scrapy_cfg
 
 _SETUP_PY_TEMPLATE = \
-"""# Automatically created by: scrapyd-deploy
+    """# Automatically created by: scrapyd-deploy
 
 from setuptools import setup, find_packages
 
@@ -34,25 +34,36 @@ setup(
 )
 """
 
+
 def parse_opts():
-    parser = OptionParser(usage="%prog [options] [ [target] | -l | -L <target> ]",
+    parser = OptionParser(
+        usage="%prog [options] [ [target] | -l | -L <target> ]",
         description="Deploy Scrapy project to Scrapyd server")
-    parser.add_option("-p", "--project",
-        help="the project name in the target")
-    parser.add_option("-v", "--version",
+    parser.add_option(
+        "-p", "--project", help="the project name in the target")
+    parser.add_option(
+        "-v", "--version",
         help="the version to deploy. Defaults to current timestamp")
-    parser.add_option("-l", "--list-targets", action="store_true", \
+    parser.add_option(
+        "-l", "--list-targets", action="store_true",
         help="list available targets")
-    parser.add_option("-a", "--deploy-all-targets",action="store_true", help="deploy all targets")
-    parser.add_option("-d", "--debug", action="store_true",
+    parser.add_option(
+        "-a", "--deploy-all-targets", action="store_true",
+        help="deploy all targets")
+    parser.add_option(
+        "-d", "--debug", action="store_true",
         help="debug mode (do not remove build dir)")
-    parser.add_option("-L", "--list-projects", metavar="TARGET", \
+    parser.add_option(
+        "-L", "--list-projects", metavar="TARGET",
         help="list available projects on TARGET")
-    parser.add_option("--egg", metavar="FILE",
+    parser.add_option(
+        "--egg", metavar="FILE",
         help="use the given egg, instead of building it")
-    parser.add_option("--build-egg", metavar="FILE",
+    parser.add_option(
+        "--build-egg", metavar="FILE",
         help="only build the egg, don't deploy it")
     return parser.parse_args()
+
 
 def main():
     opts, args = parse_opts()
@@ -79,7 +90,7 @@ def main():
 
     tmpdir = None
 
-    if opts.build_egg: # build egg only
+    if opts.build_egg:  # build egg only
         egg, tmpdir = _build_egg()
         _log("Writing egg to %s" % opts.build_egg)
         shutil.copyfile(egg, opts.build_egg)
@@ -89,7 +100,7 @@ def main():
             if version is None:
                 version = _get_version(target, opts)
             _build_egg_and_deploy_target(target, version, opts)
-    else: # buld egg and deploy
+    else:  # buld egg and deploy
         target_name = _get_target_name(args)
         target = _get_target(target_name)
         version = _get_version(target, opts)
@@ -102,6 +113,7 @@ def main():
             shutil.rmtree(tmpdir)
 
     sys.exit(exitcode)
+
 
 def _build_egg_and_deploy_target(target, version, opts):
     exitcode = 0
@@ -118,12 +130,15 @@ def _build_egg_and_deploy_target(target, version, opts):
         exitcode = 1
     return exitcode, tmpdir
 
+
 def _log(message):
     sys.stderr.write(message + os.linesep)
+
 
 def _fail(message, code=1):
     _log(message)
     sys.exit(code)
+
 
 def _get_target_name(args):
     if len(args) > 1:
@@ -133,16 +148,19 @@ def _get_target_name(args):
     elif len(args) < 1:
         return 'default'
 
+
 def _get_project(target, opts):
     project = opts.project or target.get('project')
     if not project:
         raise _fail("Error: Missing project")
     return project
 
+
 def _get_option(section, option, default=None):
     cfg = get_config()
     return cfg.get(section, option) if cfg.has_option(section, option) \
         else default
+
 
 def _get_targets():
     cfg = get_config()
@@ -157,14 +175,17 @@ def _get_targets():
             targets[x[7:]] = t
     return targets
 
+
 def _get_target(name):
     try:
         return _get_targets()[name]
     except KeyError:
         raise _fail("Unknown target: %s" % name)
 
+
 def _url(target, action):
     return urljoin(target['url'], action)
+
 
 def _get_version(target, opts):
     version = opts.version or target.get('version')
@@ -189,6 +210,7 @@ def _get_version(target, opts):
     else:
         return str(int(time.time()))
 
+
 def _upload_egg(target, eggpath, project, version):
     with open(eggpath, 'rb') as f:
         eggdata = f.read()
@@ -208,17 +230,19 @@ def _upload_egg(target, eggpath, project, version):
     _log('Deploying to project "%s" in %s' % (project, url))
     return _http_post(req)
 
+
 def _add_auth_header(request, target):
     if 'username' in target:
         u, p = target.get('username'), target.get('password', '')
         request.add_header('Authorization', basic_auth_header(u, p))
-    else: # try netrc
+    else:  # try netrc
         try:
             host = urlparse(target['url']).hostname
             a = netrc.netrc().authenticators(host)
             request.add_header('Authorization', basic_auth_header(a[0], a[2]))
         except (netrc.NetrcParseError, IOError, TypeError):
             pass
+
 
 def _http_post(request):
     try:
@@ -242,6 +266,7 @@ def _http_post(request):
     except urllib2.URLError, e:
         _log("Deploy failed: %s" % e)
 
+
 def _build_egg():
     closest = closest_scrapy_cfg()
     os.chdir(os.path.dirname(closest))
@@ -251,11 +276,15 @@ def _build_egg():
     d = tempfile.mkdtemp(prefix="scrapydeploy-")
     o = open(os.path.join(d, "stdout"), "wb")
     e = open(os.path.join(d, "stderr"), "wb")
-    retry_on_eintr(check_call, [sys.executable, 'setup.py', 'clean', '-a', 'bdist_egg', '-d', d], stdout=o, stderr=e)
+    retry_on_eintr(
+        check_call,
+        [sys.executable, 'setup.py', 'clean', '-a', 'bdist_egg', '-d', d],
+        stdout=o, stderr=e)
     o.close()
     e.close()
     egg = glob.glob(os.path.join(d, '*.egg'))[0]
     return egg, d
+
 
 def _create_default_setup_py(**kwargs):
     with open('setup.py', 'w') as f:
@@ -273,8 +302,9 @@ class HTTPRedirectHandler(urllib2.HTTPRedirectHandler):
                                    origin_req_host=req.get_origin_req_host(),
                                    unverifiable=True)
         elif code in (302, 303):
-            newheaders = dict((k, v) for k, v in req.headers.items()
-                              if k.lower() not in ("content-length", "content-type"))
+            newheaders = dict(
+                (k, v) for k, v in req.headers.items()
+                if k.lower() not in ("content-length", "content-type"))
             return urllib2.Request(newurl,
                                    headers=newheaders,
                                    origin_req_host=req.get_origin_req_host(),

--- a/scrapyd-client/scrapyd-deploy
+++ b/scrapyd-client/scrapyd-deploy
@@ -98,13 +98,15 @@ def main(args):
         version = None
         for name, target in _get_targets().items():
             if version is None:
-                version = _get_version(target, opts)
-            _build_egg_and_deploy_target(target, version, opts)
+                version = _get_version(target, opts.version)
+            _build_egg_and_deploy_target(
+                target, version, opts.project, opts.egg)
     else:  # buld egg and deploy
         target_name = _get_target_name(args)
         target = _get_target(target_name)
-        version = _get_version(target, opts)
-        exitcode, tmpdir = _build_egg_and_deploy_target(target, version, opts)
+        version = _get_version(target, opts.version)
+        exitcode, tmpdir = _build_egg_and_deploy_target(
+            target, version, opts.project, opts.egg)
 
     if tmpdir:
         if opts.debug:
@@ -115,14 +117,14 @@ def main(args):
     sys.exit(exitcode)
 
 
-def _build_egg_and_deploy_target(target, version, opts):
+def _build_egg_and_deploy_target(target, version, project, egg):
     exitcode = 0
     tmpdir = None
 
-    project = _get_project(target, opts)
-    if opts.egg:
-        _log("Using egg: %s" % opts.egg)
-        egg = opts.egg
+    project = _get_project(target, project)
+    if egg:
+        _log("Using egg: %s" % egg)
+        egg = egg
     else:
         _log("Packing version %s" % version)
         egg, tmpdir = _build_egg()
@@ -149,8 +151,8 @@ def _get_target_name(args):
         return 'default'
 
 
-def _get_project(target, opts):
-    project = opts.project or target.get('project')
+def _get_project(target, project=None):
+    project = project or target.get('project')
     if not project:
         raise _fail("Error: Missing project")
     return project
@@ -187,8 +189,8 @@ def _url(target, action):
     return urljoin(target['url'], action)
 
 
-def _get_version(target, opts):
-    version = opts.version or target.get('version')
+def _get_version(target, version=None):
+    version = version or target.get('version')
     if version == 'HG':
         p = Popen(['hg', 'tip', '--template', '{rev}'], stdout=PIPE)
         d = 'r%s' % p.communicate()[0]

--- a/scrapyd-client/scrapyd-deploy
+++ b/scrapyd-client/scrapyd-deploy
@@ -62,7 +62,8 @@ def parse_opts(args):
         help="use the given egg, instead of building it")
     parser.add_option(
         "--build-egg", metavar="FILE",
-        help="only build the egg, don't deploy it")
+        help="Path to store the built egg, if specified it will only build "
+        "the egg, not deploy it")
     return parser.parse_args(args)
 
 

--- a/scrapyd-client/scrapyd-deploy
+++ b/scrapyd-client/scrapyd-deploy
@@ -64,34 +64,67 @@ def parse_opts(args):
         "--build-egg", metavar="FILE",
         help="Path to store the built egg, if specified it will only build "
         "the egg, not deploy it")
+    parser.add_option(
+        "--pip-package", metavar="PACKAGE_SPEC",
+        help="Package to retrieve from pip, will use the source retrieved to "
+        "build the package")
     return parser.parse_args(args)
+
+
+def _get_tarball_name(pkg_name, basedir='.'):
+    _, _, files = os.walk(basedir).next()
+    try:
+        return (
+            fname for fname in files
+            if fname.startswith(pkg_name) and fname.endswith('.tar.gz')
+        ).next()
+    except StopIteration:
+        raise Exception('Tarball for %s not found in %s'
+                        % (pkg_name, basedir))
 
 
 def main(args):
     opts, args = parse_opts(args)
     exitcode = 0
-    if not inside_project():
-        _log("Error: no Scrapy project found in this location")
-        sys.exit(1)
-
-    urllib2.install_opener(urllib2.build_opener(HTTPRedirectHandler))
-
-    if opts.list_targets:
-        for name, target in _get_targets().items():
-            print "%-20s %s" % (name, target['url'])
-        return
-
-    if opts.list_projects:
-        target = _get_target(opts.list_projects)
-        req = urllib2.Request(_url(target, 'listprojects.json'))
-        _add_auth_header(req, target)
-        f = urllib2.urlopen(req)
-        projects = json.loads(f.read())['projects']
-        print os.linesep.join(projects)
-        return
-
     tmpdir = tempfile.mkdtemp(prefix="scrapydeploy-")
     try:
+        if opts.pip_package:
+            os.chdir(tmpdir)
+            _retry_command(
+                tmpdir,
+                check_call,
+                ['pip', 'download', '--no-deps', opts.pip_package],
+            )
+            pkg_name = opts.pip_package.split('=')[0]
+            tarball = _get_tarball_name(pkg_name)
+            _retry_command(
+                tmpdir,
+                check_call,
+                ['tar', 'xvzf', tarball]
+            )
+            os.chdir(tarball[:-7])
+
+        if not inside_project():
+            _log("Error: no Scrapy project found in this location")
+            sys.exit(1)
+
+        urllib2.install_opener(urllib2.build_opener(HTTPRedirectHandler))
+
+        if opts.list_targets:
+            for name, target in _get_targets().items():
+                print "%-20s %s" % (name, target['url'])
+            return
+
+        if opts.list_projects:
+            target = _get_target(opts.list_projects)
+            req = urllib2.Request(_url(target, 'listprojects.json'))
+            _add_auth_header(req, target)
+            f = urllib2.urlopen(req)
+            projects = json.loads(f.read())['projects']
+            print os.linesep.join(projects)
+            return
+
+
         if opts.build_egg:  # build egg only
             _build_egg(tmpdir, dest=opts.build_egg)
         elif opts.deploy_all_targets:
@@ -271,16 +304,11 @@ def _build_egg(tmpdir, dest=None):
         settings = get_config().get('settings', 'default')
         _create_default_setup_py(settings=settings)
 
-    with open(
-            os.path.join(tmpdir, "stdout"), "wb"
-    ) as stdout, open(
-            os.path.join(tmpdir, "stderr"), "wb"
-    ) as stderr:
-        retry_on_eintr(
-            check_call,
-            [sys.executable, 'setup.py', 'clean', '-a', 'bdist_egg', '-d',
-             tmpdir],
-            stdout=stdout, stderr=stderr)
+    _retry_command(
+        tmpdir,
+        check_call,
+        [sys.executable, 'setup.py', 'clean', '-a', 'bdist_egg', '-d', tmpdir]
+    )
 
     egg = glob.glob(os.path.join(tmpdir, '*.egg'))[0]
 
@@ -289,6 +317,18 @@ def _build_egg(tmpdir, dest=None):
         shutil.copyfile(egg, dest)
 
     return egg
+
+
+def _retry_command(tmpdir, *args, **kwargs):
+    with open(
+            os.path.join(tmpdir, "stdout"), "wb"
+    ) as stdout, open(
+            os.path.join(tmpdir, "stderr"), "wb"
+    ) as stderr:
+        kwargs['stdout'] = stdout
+        kwargs['stdin'] = stderr
+        retry_on_eintr(*args, **kwargs)
+
 
 
 def _create_default_setup_py(**kwargs):

--- a/scrapyd-client/scrapyd-deploy
+++ b/scrapyd-client/scrapyd-deploy
@@ -21,6 +21,7 @@ from scrapy.utils.http import basic_auth_header
 from scrapy.utils.python import retry_on_eintr
 from scrapy.utils.conf import get_config, closest_scrapy_cfg
 
+
 _SETUP_PY_TEMPLATE = \
     """# Automatically created by: scrapyd-deploy
 
@@ -88,49 +89,42 @@ def main(args):
         print os.linesep.join(projects)
         return
 
-    tmpdir = None
+    tmpdir = tempfile.mkdtemp(prefix="scrapydeploy-")
+    try:
+        if opts.build_egg:  # build egg only
+            _build_egg(tmpdir, dest=opts.build_egg)
+        elif opts.deploy_all_targets:
+            for name, target in _get_targets().items():
+                exitcode += _deploy_target(target, tmpdir, opts.version,
+                                           opts.project, opts.egg)
+        else:  # buld egg and deploy
+            target_name = _get_target_name(args)
+            target = _get_target(target_name)
+            exitcode = _deploy_target(target, tmpdir, opts.version,
+                                      opts.project, opts.egg)
 
-    if opts.build_egg:  # build egg only
-        egg, tmpdir = _build_egg()
-        _log("Writing egg to %s" % opts.build_egg)
-        shutil.copyfile(egg, opts.build_egg)
-    elif opts.deploy_all_targets:
-        version = None
-        for name, target in _get_targets().items():
-            if version is None:
-                version = _get_version(target, opts.version)
-            _build_egg_and_deploy_target(
-                target, version, opts.project, opts.egg)
-    else:  # buld egg and deploy
-        target_name = _get_target_name(args)
-        target = _get_target(target_name)
-        version = _get_version(target, opts.version)
-        exitcode, tmpdir = _build_egg_and_deploy_target(
-            target, version, opts.project, opts.egg)
-
-    if tmpdir:
-        if opts.debug:
-            _log("Output dir not removed: %s" % tmpdir)
-        else:
-            shutil.rmtree(tmpdir)
-
-    sys.exit(exitcode)
+        sys.exit(exitcode)
+    finally:
+        if tmpdir:
+            if opts.debug:
+                _log("Output dir not removed: %s" % tmpdir)
+            else:
+                shutil.rmtree(tmpdir)
 
 
-def _build_egg_and_deploy_target(target, version, project, egg):
+def _deploy_target(target, tmpdir, version=None, project=None, egg=None):
     exitcode = 0
-    tmpdir = None
-
-    project = _get_project(target, project)
+    version = version or _get_version(target, version)
+    project = project or _get_project(target, project)
     if egg:
         _log("Using egg: %s" % egg)
         egg = egg
     else:
         _log("Packing version %s" % version)
-        egg, tmpdir = _build_egg()
+        egg = _build_egg(tmpdir)
     if not _upload_egg(target, egg, project, version):
         exitcode = 1
-    return exitcode, tmpdir
+    return exitcode
 
 
 def _log(message):
@@ -269,23 +263,31 @@ def _http_post(request):
         _log("Deploy failed: %s" % e)
 
 
-def _build_egg():
+def _build_egg(tmpdir, dest=None):
     closest = closest_scrapy_cfg()
     os.chdir(os.path.dirname(closest))
     if not os.path.exists('setup.py'):
         settings = get_config().get('settings', 'default')
         _create_default_setup_py(settings=settings)
-    d = tempfile.mkdtemp(prefix="scrapydeploy-")
-    o = open(os.path.join(d, "stdout"), "wb")
-    e = open(os.path.join(d, "stderr"), "wb")
-    retry_on_eintr(
-        check_call,
-        [sys.executable, 'setup.py', 'clean', '-a', 'bdist_egg', '-d', d],
-        stdout=o, stderr=e)
-    o.close()
-    e.close()
-    egg = glob.glob(os.path.join(d, '*.egg'))[0]
-    return egg, d
+
+    with open(
+            os.path.join(tmpdir, "stdout"), "wb"
+    ) as stdout, open(
+            os.path.join(tmpdir, "stderr"), "wb"
+    ) as stderr:
+        retry_on_eintr(
+            check_call,
+            [sys.executable, 'setup.py', 'clean', '-a', 'bdist_egg', '-d',
+             tmpdir],
+            stdout=stdout, stderr=stderr)
+
+    egg = glob.glob(os.path.join(tmpdir, '*.egg'))[0]
+
+    if dest:
+        _log("Writing egg to %s" % dest)
+        shutil.copyfile(egg, dest)
+
+    return egg
 
 
 def _create_default_setup_py(**kwargs):


### PR DESCRIPTION
This (aside from the small refactor) adds the possibility to download the spider directly from pip, using pip download command, allowing to specify version restrictions and similar.

Created on top of the other pull requests as it uses their code, will rebase once the others are merged.

IMO this is a better alternative to #23, though #23 adds the capability to override the config files options from the downloaded source code (that's good) and allows downloading the egg file from anywhere, not just pip, so may be complementary.
