### PR TITLE
Allow using a url when specifying the egg path

### DIFF
--- a/scrapyd-client/scrapyd-deploy
+++ b/scrapyd-client/scrapyd-deploy
@@ -48,8 +48,9 @@ def parse_opts():
         help="debug mode (do not remove build dir)")
     parser.add_option("-L", "--list-projects", metavar="TARGET", \
         help="list available projects on TARGET")
-    parser.add_option("--egg", metavar="FILE",
-        help="use the given egg, instead of building it")
+    parser.add_option("--egg", metavar="FILE/URL",
+        help="use and download if needed the given egg, instead of building "
+        "it")
     parser.add_option("--build-egg", metavar="FILE",
         help="only build the egg, don't deploy it")
     return parser.parse_args()
@@ -89,7 +90,7 @@ def main():
             if version is None:
                 version = _get_version(target, opts)
             _build_egg_and_deploy_target(target, version, opts)
-    else: # buld egg and deploy
+    else: # buld/retrieve egg and deploy
         target_name = _get_target_name(args)
         target = _get_target(target_name)
         version = _get_version(target, opts)
@@ -186,8 +187,16 @@ def _get_version(target, opts):
         return str(int(time.time()))
 
 def _upload_egg(target, eggpath, project, version):
-    with open(eggpath, 'rb') as f:
+    if eggpath.startswith('http'):
+        eggdata = urllib2.Request
+        req = urllib2.Request(eggpath)
+        f = urllib2.urlopen(req)
         eggdata = f.read()
+
+    else:
+        with open(eggpath, 'rb') as f:
+            eggdata = f.read()
+
     data = {
         'project': project,
         'version': version,


### PR DESCRIPTION
That enables the cli to download a remote egg and deploy it on the
server instead of having to have the egg locally, skipping an
intermediate download step.

Signed-off-by: David Caro david@dcaro.es
