### PR TITLE
Popen.communicate returns bytes in Python3 whereas it returns strings in Python2

### DIFF
--- a/scrapyd-client/scrapyd-deploy
+++ b/scrapyd-client/scrapyd-deploy
@@ -174,19 +174,19 @@ def _url(target, action):
 def _get_version(target, opts):
     version = opts.version or target.get('version')
     if version == 'HG':
-        p = Popen(['hg', 'tip', '--template', '{rev}'], stdout=PIPE)
+        p = Popen(['hg', 'tip', '--template', '{rev}'], stdout=PIPE, universal_newlines=True)
         d = 'r%s' % p.communicate()[0]
-        p = Popen(['hg', 'branch'], stdout=PIPE)
+        p = Popen(['hg', 'branch'], stdout=PIPE, universal_newlines=True)
         b = p.communicate()[0].strip('\n')
         return '%s-%s' % (d, b)
     elif version == 'GIT':
-        p = Popen(['git', 'describe'], stdout=PIPE)
+        p = Popen(['git', 'describe'], stdout=PIPE, universal_newlines=True)
         d = p.communicate()[0].strip('\n')
         if p.wait() != 0:
-            p = Popen(['git', 'rev-list', '--count', 'HEAD'], stdout=PIPE)
+            p = Popen(['git', 'rev-list', '--count', 'HEAD'], stdout=PIPE, universal_newlines=True)
             d = 'r%s' % p.communicate()[0].strip('\n')
 
-        p = Popen(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], stdout=PIPE)
+        p = Popen(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], stdout=PIPE, universal_newlines=True)
         b = p.communicate()[0].strip('\n')
         return '%s-%s' % (d, b)
     elif version:


### PR DESCRIPTION
The ```TypeError: 'str' does not support the buffer interface``` will raise when using Git or Mercurial version during deployment. This is because ```Popen.communicate``` returns bytes in Python3 by default whereas it returns string in Python2. As noted [here](https://docs.python.org/3.6/library/subprocess.html#subprocess.Popen.communicate), this function In Python3 will return strings if streams were opened in text mode when encoding or errors are specified or universal_newlines is true; otherwise, bytes.

This issue is fixed by passing ```universal_newlines=True``` to ```Popen.communicate``` function.  [In Python2](https://docs.python.org/2/library/subprocess.html#frequently-used-arguments), this makes all line endings will be converted to ```\n``` and function still returns as strings. In Python3, this makes sure ```communicate``` returning strings in text mode and line endings will also be converted to ```\n```.