### PR TITLE
Default to current timestamp egg file name when a dir is passed to --…

### DIFF
--- a/scrapyd_client/deploy.py
+++ b/scrapyd_client/deploy.py
@@ -88,8 +88,11 @@ def main():
 
     if opts.build_egg:  # build egg only
         egg, tmpdir = _build_egg()
-        _log("Writing egg to %s" % opts.build_egg)
-        shutil.copyfile(egg, opts.build_egg)
+        dest = opts.build_egg
+        if(os.path.isdir(dest)):
+            dest = os.path.join(dest, str(int(time.time())) + '.egg')
+        _log("Writing egg to %s" % dest)
+        shutil.copyfile(egg, dest)
     elif opts.deploy_all_targets:
         version = None
         for name, target in _get_targets().items():


### PR DESCRIPTION
Default the file name of the --build-egg output to the current timestamp in the case just a folder is passed as parameter. In the case the parameter is a file the behaviour  remain exactly the same as before.

Example : 

scrapyd-deploy --build-egg /home/user/
 /home/user/1511341699.egg file generated ...


I've implemented it, since I have a docker image build script that generate the egg and then copy to the docker image all the generated eggs in a given folder...