### PR TITLE
Fix ScrapyDeprecationWarning when calling scrapy.utils.python.retry_on_eintr 

### DIFF
--- a/scrapyd_client/deploy.py
+++ b/scrapyd_client/deploy.py
@@ -21,8 +21,8 @@ import setuptools  # noqa: F401 not used in code but needed in runtime, don't re
 
 from scrapy.utils.project import inside_project
 from scrapy.utils.http import basic_auth_header
-from scrapy.utils.python import retry_on_eintr
 from scrapy.utils.conf import get_config, closest_scrapy_cfg
+from scrapyd_client.utils import retry_on_eintr
 
 _SETUP_PY_TEMPLATE = """
 # Automatically created by: scrapyd-deploy

--- a/scrapyd_client/utils.py
+++ b/scrapyd_client/utils.py
@@ -81,5 +81,6 @@ __all__ = [
     MalformedRespone.__name__,
     get_request.__name__,
     indent.__name__,
-    post_request.__name__
+    post_request.__name__,
+    retry_on_eintr.__name__
 ]

--- a/scrapyd_client/utils.py
+++ b/scrapyd_client/utils.py
@@ -1,3 +1,4 @@
+import errno
 from os.path import dirname, join
 import sys
 
@@ -95,6 +96,16 @@ def post_request(url, data):
     """
     response = requests.post(url, data=data, headers=HEADERS)
     return _process_response(response)
+
+
+def retry_on_eintr(function, *args, **kw):
+    """Run a function and retry it while getting EINTR errors"""
+    while True:
+        try:
+            return function(*args, **kw)
+        except IOError as e:
+            if e.errno != errno.EINTR:
+                raise
 
 
 __all__ = [


### PR DESCRIPTION
This PR fixes ScrapyDeprecationWarning and applies suggested fix from scrapy/scrapy#4683.
It will avoid breaking the code when it is indeed removed from scrapy code base.

closes #69