### PR TITLE
Get tests passing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,16 +8,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - python-version: 2.7
-          env:
-            TOXENV: py
-        - python-version: 3.4
-          env:
-            TOXENV: py
-        - python-version: 3.5
-          env:
-            TOXENV: py
         - python-version: 3.6
+          env:
+            TOXENV: py
+        - python-version: 3.7
+          env:
+            TOXENV: py
+        - python-version: 3.8
+          env:
+            TOXENV: py
+        - python-version: 3.9
           env:
             TOXENV: py
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,39 @@
+name: Tests
+on: [push, pull_request]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - python-version: 2.7
+          env:
+            TOXENV: py
+        - python-version: 3.4
+          env:
+            TOXENV: py
+        - python-version: 3.5
+          env:
+            TOXENV: py
+        - python-version: 3.6
+          env:
+            TOXENV: py
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Run tests
+      env: ${{ matrix.env }}
+      run: |
+        pip install -U tox
+        tox
+
+    - name: Upload coverage report
+      run: bash <(curl -s https://codecov.io/bash)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Changes
 =======
 
+2.0.0 (Unreleased)
+------------------
+
+- Add support for Scrapy 2.5.
+- Add support for Python 3.7, 3.8, 3.9.
+- Drop support for Python 2.7, 3.4, 3.5.
+- Remove ``scrapyd_client.utils.get_config``, which was a compatibility wrapper for Python 2.7.
+
+
 1.2.0a1 (2017-08-24)
 --------------------
 

--- a/scrapyd_client/cli.py
+++ b/scrapyd_client/cli.py
@@ -5,9 +5,10 @@ from argparse import ArgumentParser
 from traceback import print_exc
 
 from requests.exceptions import ConnectionError
+from scrapy.utils.conf import get_config
 
 from scrapyd_client import commands
-from scrapyd_client.utils import ErrorResponse, MalformedRespone, get_config
+from scrapyd_client.utils import ErrorResponse, MalformedRespone
 
 
 DEFAULT_TARGET_URL = 'http://localhost:6800'
@@ -15,8 +16,10 @@ ISSUE_TRACKER_URL = 'https://github.com/scrapy/scrapyd-client/issues'
 
 
 def parse_cli_args(args):
-    target_default = get_config('deploy', 'url', fallback=DEFAULT_TARGET_URL).rstrip('/')
-    project_default = get_config('deploy', 'project', fallback=None)
+    cfg = get_config()
+
+    target_default = cfg.get('deploy', 'url', fallback=DEFAULT_TARGET_URL).rstrip('/')
+    project_default = cfg.get('deploy', 'project', fallback=None)
     project_kwargs = {
         'metavar': 'PROJECT', 'required': True,
         'help': 'Specifies the project, can be a globbing pattern.'
@@ -73,7 +76,7 @@ def main():
     except SystemExit as e:
         exit_code = e.code
     except ConnectionError as e:
-        print('Failed to connect to target ({}):'.format(args.target))
+        print(f'Failed to connect to target ({args.target}):')
         print(e)
         exit_code = 1
     except ErrorResponse as e:
@@ -88,7 +91,7 @@ def main():
         print(text)
         exit_code = 1
     except Exception:
-        print('Caught unhandled exception, please report at {}'.format(ISSUE_TRACKER_URL))
+        print(f'Caught unhandled exception, please report at {ISSUE_TRACKER_URL}')
         print_exc()
         exit_code = 3
     else:

--- a/scrapyd_client/commands.py
+++ b/scrapyd_client/commands.py
@@ -31,7 +31,7 @@ def schedule(args):
         _spiders = lib.get_spiders(args.target, project, args.spider)
         for spider in _spiders:
             job_id = lib.schedule(args.target, project, spider, job_args)
-            print('{} / {} => {}'.format(project, spider, job_id))
+            print(f'{project} / {spider} => {job_id}')
 
 
 def spiders(args):
@@ -40,10 +40,10 @@ def spiders(args):
     for project in _projects:
         project_spiders = lib.get_spiders(args.target, project)
         if not args.verbose:
-            print('{}:'.format(project))
+            print(f'{project}:')
             if project_spiders:
                 print(indent('\n'.join(project_spiders), INDENT_PREFIX))
             else:
                 print(INDENT_PREFIX + 'No spiders.')
         elif project_spiders:
-            print('\n'.join('{} {}'.format(project, x) for x in project_spiders))
+            print('\n'.join(f'{project} {x}' for x in project_spiders))

--- a/scrapyd_client/deploy.py
+++ b/scrapyd_client/deploy.py
@@ -16,10 +16,10 @@ from urllib.request import (build_opener, install_opener,
 from subprocess import Popen, PIPE, check_call
 
 from w3lib.form import encode_multipart
+from w3lib.http import basic_auth_header
 import setuptools  # noqa: F401 not used in code but needed in runtime, don't remove!
 
 from scrapy.utils.project import inside_project
-from scrapy.utils.http import basic_auth_header
 from scrapy.utils.python import retry_on_eintr
 from scrapy.utils.conf import get_config, closest_scrapy_cfg
 

--- a/scrapyd_client/deploy.py
+++ b/scrapyd_client/deploy.py
@@ -6,14 +6,13 @@ import glob
 import tempfile
 import shutil
 import time
-from six.moves.urllib.request import (build_opener, install_opener,
-                                      HTTPRedirectHandler as UrllibHTTPRedirectHandler,
-                                      Request, urlopen)
-from six.moves.urllib.error import HTTPError, URLError
 import netrc
 import json
 from optparse import OptionParser
-from six.moves.urllib.parse import urlparse, urljoin
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse, urljoin
+from urllib.request import (build_opener, install_opener,
+                            HTTPRedirectHandler as UrllibHTTPRedirectHandler, Request, urlopen)
 from subprocess import Popen, PIPE, check_call
 
 from w3lib.form import encode_multipart
@@ -245,11 +244,11 @@ def _http_post(request):
     try:
         f = urlopen(request)
         _log("Server response (%s):" % f.code)
-        print(f.read().decode('utf-8'))
+        print(f.read().decode())
         return True
     except HTTPError as e:
         _log("Deploy failed (%s):" % e.code)
-        resp = e.read().decode('utf-8')
+        resp = e.read().decode()
         try:
             d = json.loads(resp)
         except ValueError:

--- a/scrapyd_client/utils.py
+++ b/scrapyd_client/utils.py
@@ -1,15 +1,15 @@
+from json.decoder import JSONDecodeError
 from os.path import dirname, join
-import sys
+from textwrap import indent
 
 import requests
-from scrapy.utils.conf import get_config as get_scrapy_config
 
 
 with open(join(dirname(__file__), 'VERSION'), 'rt') as f:
     VERSION = f.readline().strip()
 
 HEADERS = requests.utils.default_headers().copy()
-HEADERS['User-Agent'] = 'Scrapyd-client/{}'.format(VERSION)
+HEADERS['User-Agent'] = f'Scrapyd-client/{VERSION}'
 
 
 class ErrorResponse(Exception):
@@ -20,38 +20,6 @@ class ErrorResponse(Exception):
 class MalformedRespone(Exception):
     """ Raised when the response can't be decoded. """
     pass
-
-
-if sys.version_info < (3,):
-    from ConfigParser import NoOptionError, NoSectionError
-else:
-    from configparser import NoOptionError, NoSectionError
-
-
-if sys.version_info < (3, 3):
-    def indent(s, prefix):
-        return '\n'.join(prefix + x for x in s.splitlines())
-else:
-    from textwrap import indent  # noqa: F401
-
-
-if sys.version_info < (3, 5):
-    JSONDecodeError = ValueError
-else:
-    from json.decoder import JSONDecodeError
-
-
-scrapy_config = get_scrapy_config()
-
-
-def get_config(section, option, fallback):
-    """ Compatibilty wrapper for Python 2.7 which lacks the fallback parameter
-        in :meth:`ConfigParser.ConfigParser.get`. """
-    # TODO remove when Python 2 support is dropped.
-    try:
-        return scrapy_config.get(section, option)
-    except (NoOptionError, NoSectionError):
-        return fallback
 
 
 def _process_response(response):
@@ -67,7 +35,7 @@ def _process_response(response):
     elif status == 'error':
         raise ErrorResponse(response['message'])
     else:
-        raise RuntimeError('Unhandled response status: {}'.format(status))
+        raise RuntimeError(f'Unhandled response status: {status}')
 
     return response
 
@@ -100,7 +68,6 @@ def post_request(url, data):
 __all__ = [
     ErrorResponse.__name__,
     MalformedRespone.__name__,
-    get_config.__name__,
     get_request.__name__,
     indent.__name__,
     post_request.__name__

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup_args = {
     'maintainer_email': 'info@scrapy.org',
     'license': 'BSD',
     'packages': ['scrapyd_client'],
+    'python_requires': '>=3.6',
     'entry_points': {
         'console_scripts': ['scrapyd-deploy = scrapyd_client.deploy:main',
                             'scrapyd-client = scrapyd_client.cli:main']
@@ -22,10 +23,11 @@ setup_args = {
     'zip_safe': False,
     'classifiers': [
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Development Status :: 5 - Production/Stable',
@@ -39,6 +41,6 @@ try:
 except ImportError:
     from distutils.core import setup
 else:
-    setup_args['install_requires'] = ['requests', 'Scrapy>=0.17', 'six']
+    setup_args['install_requires'] = ['requests', 'Scrapy>=0.17']
 
 setup(**setup_args)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,flake8
+envlist = py36,py37,py38,py39,flake8
 
 [testenv]
 deps=
@@ -19,10 +19,3 @@ max-line-length = 100
 
 [pytest]
 mock_use_standalone_module = true
-
-[travis]
-python =
-  2.7: py27
-  3.4: py34
-  3.5: py35
-  3.6: py36,flake8


### PR DESCRIPTION
- Fix "ModuleNotFoundError: No module named 'scrapy.utils.http'"
- Drop support for Python < 3.6
- Add Tests GitHub Actions workflow

closes #72
closes #78
closes #68
closes #73
closes #76