### PR TITLE
chore: Address w3lib deprecation. Add urllib3 dependency.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 History
 -------
 
+Unreleased
+~~~~~~~~~~
+
+- Address deprecation warnings.
+- Add dependency on ``urllib3``.
+
+
 1.2.0 (2021-10-01)
 ~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ the version parameter by adding it to your target's entry in ``scrapy.cfg``:
 
 .. code-block:: ini
 
-   [deploy:target]
+   [deploy]
    ...
    version = HG
 

--- a/scrapyd_client/deploy.py
+++ b/scrapyd_client/deploy.py
@@ -15,8 +15,8 @@ from urllib.request import (build_opener, install_opener,
                             HTTPRedirectHandler as UrllibHTTPRedirectHandler, Request, urlopen)
 from subprocess import Popen, PIPE, check_call
 
-from w3lib.form import encode_multipart
 from w3lib.http import basic_auth_header
+from urllib3.filepost import encode_multipart_formdata
 import setuptools  # noqa: F401 not used in code but needed in runtime, don't remove!
 
 from scrapy.utils.project import inside_project
@@ -207,10 +207,10 @@ def _upload_egg(target, eggpath, project, version):
         'version': version,
         'egg': ('project.egg', eggdata),
     }
-    body, boundary = encode_multipart(data)
+    body, content_type = encode_multipart_formdata(data)
     url = _url(target, 'addversion.json')
     headers = {
-        'Content-Type': 'multipart/form-data; boundary=%s' % boundary,
+        'Content-Type': content_type,
         'Content-Length': str(len(body)),
     }
     req = Request(url, body, headers)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     install_requires=[
         'requests',
         'scrapy>=0.17',
+        'urllib3',
         'w3lib',
     ],
     extras_require={


### PR DESCRIPTION
closes #90 

I tried:

```python
import difflib

from urllib3.filepost import encode_multipart_formdata
from w3lib.form import encode_multipart

data = {'project': 'foo', 'version': '123', 'egg': ('project.egg', b'foo')}

a, boundary = encode_multipart(data)
b, content_type = encode_multipart_formdata(data, boundary=boundary)

diff = difflib.ndiff(a.decode().splitlines(keepends=True), b.decode().splitlines(keepends=True))
print(''.join(diff), end="")
```

Output:

```diff
- 
  ----------------GHSKFJDLGDS7543FJKLFHRE75642756743254
  Content-Disposition: form-data; name="project"
  
  foo
  ----------------GHSKFJDLGDS7543FJKLFHRE75642756743254
  Content-Disposition: form-data; name="version"
  
  123
  ----------------GHSKFJDLGDS7543FJKLFHRE75642756743254
  Content-Disposition: form-data; name="egg"; filename="project.egg"
+ Content-Type: application/octet-stream
  
  foo
  ----------------GHSKFJDLGDS7543FJKLFHRE75642756743254--
```

This seems fine to me.