### PR TITLE
chore(scrapyd-deploy): --list-projects now uses the TARGET positional argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ History
 Unreleased
 ~~~~~~~~~~
 
+- ``scrapyd-deploy``: ``--list-projects`` (``-L``) now uses the ``TARGET`` positional argument instead of accepting a ``TARGET`` option.
 - Address deprecation warnings.
 - Add dependency on ``urllib3``.
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include *.py
 include *.rst
 include LICENSE
 include scrapyd_client/VERSION

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+import scrapy.utils.conf as conf
+
+
+@pytest.fixture(autouse=True)
+def only_closest_scrapy_cfg(monkeypatch):
+    """
+    Avoids a developer's own configuration files interfering with tests.
+    """
+    def get_sources(use_closest=True):
+        if use_closest:
+            return [conf.closest_scrapy_cfg()]
+        return []
+
+    monkeypatch.setattr(conf, 'get_sources', get_sources)

--- a/scrapyd_client/deploy.py
+++ b/scrapyd_client/deploy.py
@@ -143,12 +143,6 @@ def _get_project(target, opts):
     return project
 
 
-def _get_option(section, option, default=None):
-    cfg = get_config()
-    return cfg.get(section, option) if cfg.has_option(section, option) \
-        else default
-
-
 def _get_targets():
     cfg = get_config()
     baset = dict(cfg.items('deploy')) if cfg.has_section('deploy') else {}

--- a/scrapyd_client/deploy.py
+++ b/scrapyd_client/deploy.py
@@ -40,9 +40,9 @@ setup(
 
 def parse_args():
     parser = ArgumentParser(description="Deploy Scrapy project to Scrapyd server")
-    parser.add_argument('target', nargs='?', default='default')
+    parser.add_argument('target', nargs='?', metavar='TARGET', default='default')
     parser.add_argument("-p", "--project",
-                        help="the project name in the target")
+                        help="the project name in the TARGET")
     parser.add_argument("-v", "--version",
                         help="the version to deploy. Defaults to current timestamp")
     parser.add_argument("-l", "--list-targets", action="store_true",
@@ -51,8 +51,8 @@ def parse_args():
                         help="deploy all targets")
     parser.add_argument("-d", "--debug", action="store_true",
                         help="debug mode (do not remove build dir)")
-    parser.add_argument("-L", "--list-projects", metavar="TARGET",
-                        help="list available projects on TARGET")
+    parser.add_argument("-L", "--list-projects", action="store_true",
+                        help="list available projects in the TARGET")
     parser.add_argument("--egg", metavar="FILE",
                         help="use the given egg, instead of building it")
     parser.add_argument("--build-egg", metavar="FILE",
@@ -77,7 +77,7 @@ def main():
         return
 
     if opts.list_projects:
-        target = _get_target(opts.list_projects)
+        target = _get_target(opts.target)
         req = Request(_url(target, 'listprojects.json'))
         _add_auth_header(req, target)
         f = urlopen(req)

--- a/tests/test_scrapyd-deploy.py
+++ b/tests/test_scrapyd-deploy.py
@@ -103,9 +103,9 @@ def test_too_many_arguments(script_runner, project):
     assert not ret.success
     assert ret.stdout == ''
     assertLines(ret.stderr, dedent("""\
-        usage: scrapyd-deploy [-h] [-p PROJECT] [-v VERSION] [-l] [-a] [-d]
-                              [-L TARGET] [--egg FILE] [--build-egg FILE]
-                              [target]
+        usage: scrapyd-deploy [-h] [-p PROJECT] [-v VERSION] [-l] [-a] [-d] [-L]
+                              [--egg FILE] [--build-egg FILE]
+                              [TARGET]
         scrapyd-deploy: error: unrecognized arguments: extra
     """))
 

--- a/tests/test_scrapyd-deploy.py
+++ b/tests/test_scrapyd-deploy.py
@@ -71,10 +71,46 @@ def conf_no_project(project):
 
 
 @pytest.fixture
-def conf(project):
+def conf_no_url(project):
+    _write_conf_file("""\
+        [deploy:mytarget]
+        project = scrapydproject
+    """)
+
+
+@pytest.fixture
+def conf_default_target(project):
     _write_conf_file("""\
         [deploy]
         url = http://localhost:6800/
+        project = scrapydproject
+    """)
+
+
+@pytest.fixture
+def conf_named_targets(project):
+    # target2 is deliberately before target 1, to test ordering.
+    _write_conf_file("""\
+        [deploy:target2]
+        url = http://localhost:6802/
+        project = anotherproject
+
+        [deploy:target1]
+        url = http://localhost:6801/
+        project = scrapydproject
+    """)
+
+
+@pytest.fixture
+def conf_mixed_targets(project):
+    # target2 is deliberately before target 1, to test ordering.
+    _write_conf_file("""\
+        [deploy]
+        url = http://localhost:6800/
+        project = anotherproject
+
+        [deploy:target1]
+        url = http://localhost:6801/
         project = scrapydproject
     """)
 
@@ -89,15 +125,17 @@ def assertLines(actual, expected):
             assert re.search(f'^{expected[i]}$', line), f'{line} does not match {expected[i]}'
 
 
-def test_not_in_project(script_runner):
-    ret = script_runner.run('scrapyd-deploy', '-l')
+@pytest.mark.parametrize('args', [[], ['-l'], ['-L']])
+def test_not_in_project(args, script_runner):
+    ret = script_runner.run('scrapyd-deploy', *args)
 
     assert not ret.success
     assert ret.stdout == ''
     assertLines(ret.stderr, 'Error: no Scrapy project found in this location')
 
 
-def test_too_many_arguments(script_runner, project):
+@pytest.mark.parametrize('args', [[], ['-l'], ['-L']])
+def test_too_many_arguments(args, script_runner, project):
     ret = script_runner.run('scrapyd-deploy', 'mytarget', 'extra')
 
     assert not ret.success
@@ -108,6 +146,37 @@ def test_too_many_arguments(script_runner, project):
                               [TARGET]
         scrapyd-deploy: error: unrecognized arguments: extra
     """))
+
+
+@pytest.mark.xfail(reason='raises KeyError')
+def test_list_targets_missing_url(script_runner, conf_no_url):
+    ret = script_runner.run('scrapyd-deploy', 'mytarget')
+
+    assert not ret.success
+    assert ret.stdout == ''
+    assertLines(ret.stderr, 'Error: Missing url for project')
+
+
+def test_list_targets_with_default(script_runner, conf_mixed_targets):
+    ret = script_runner.run('scrapyd-deploy', '-l')
+
+    assert ret.success
+    assertLines(ret.stdout, dedent("""\
+        default              http://localhost:6800/
+        target1              http://localhost:6801/
+    """))
+    assert ret.stderr == ''
+
+
+def test_list_targets_without_default(script_runner, conf_named_targets):
+    ret = script_runner.run('scrapyd-deploy', '-l')
+
+    assert ret.success
+    assertLines(ret.stdout, dedent("""\
+        target2              http://localhost:6802/
+        target1              http://localhost:6801/
+    """))
+    assert ret.stderr == ''
 
 
 def test_unknown_target_implicit(script_runner, project):
@@ -142,12 +211,21 @@ def test_empty_section_explicit_target(script_runner, conf_empty_section_explici
     assertLines(ret.stderr, 'Error: Missing project')
 
 
-def test_missing_project(script_runner, conf_no_project):
+def test_deploy_missing_project(script_runner, conf_no_project):
     ret = script_runner.run('scrapyd-deploy')
 
     assert not ret.success
     assert ret.stdout == ''
     assertLines(ret.stderr, 'Error: Missing project')
+
+
+@pytest.mark.xfail(reason='raises KeyError')
+def test_deploy_missing_url(script_runner, conf_no_url):
+    ret = script_runner.run('scrapyd-deploy', 'mytarget')
+
+    assert not ret.success
+    assert ret.stdout == ''
+    assertLines(ret.stderr, 'Error: Missing url for project')
 
 
 def test_build_egg(script_runner, project):
@@ -158,7 +236,7 @@ def test_build_egg(script_runner, project):
     assertLines(ret.stderr, 'Writing egg to myegg.egg')
 
 
-def test_deploy_success(script_runner, conf):
+def test_deploy_success(script_runner, conf_default_target):
     with patch('scrapyd_client.deploy.urlopen') as mocked:
         # https://scrapyd.readthedocs.io/en/stable/api.html#addversion-json
         mocked.return_value.code = 200
@@ -180,7 +258,7 @@ def test_deploy_success(script_runner, conf):
     (b'["content"]', '[\n   "content"\n]'),
     (b'{"status": "error", "message": "content"}', 'Status: error\nMessage:\ncontent'),
 ])
-def test_deploy_httperror(content, expected, script_runner, conf):
+def test_deploy_httperror(content, expected, script_runner, conf_default_target):
     with patch('scrapyd_client.deploy.urlopen') as mocked:
         # https://scrapyd.readthedocs.io/en/stable/api.html#addversion-json
         mocked.side_effect = HTTPError(
@@ -202,7 +280,7 @@ def test_deploy_httperror(content, expected, script_runner, conf):
         ])
 
 
-def test_deploy_urlerror(script_runner, conf):
+def test_deploy_urlerror(script_runner, conf_default_target):
     with patch('scrapyd_client.deploy.urlopen') as mocked:
         # https://scrapyd.readthedocs.io/en/stable/api.html#addversion-json
         mocked.side_effect = URLError(reason='content')


### PR DESCRIPTION
closes #93

I'm not sure what version level this change belongs to (major/minor/patch). Thoughts?

In light of #96 and #97, maybe better to jump ahead to a 2.0.0 release?