### PR TITLE
Fix incorrect `.netrc` example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -298,7 +298,7 @@ While your target needs to be defined with its URL in ``scrapy.cfg``,
 you can use netrc_ for username and password, like so::
 
    machine scrapyd.example.com
-       username scrapy
+       login scrapy
        password secret
 
 .. _netrc: https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html


### PR DESCRIPTION
The token to identify the user is `login` instead of `username`. Ref. https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html