### PR TITLE
feat: add ScrapydClient.status

### DIFF
--- a/scrapyd_client/pyclient.py
+++ b/scrapyd_client/pyclient.py
@@ -40,6 +40,13 @@ class ScrapydClient:
         response = self._post("schedule", data=[*args, ("project", project), ("spider", spider)])
         return response["jobid"]
 
+    def status(self, jobid: str, project: str | None = None) -> dict:
+        params = {"job": jobid}
+        if project is not None:
+            params["project"] = project
+
+        return self._get("status", params)
+
     def _get(self, basename: str, params=None):
         if params is None:
             params = {}


### PR DESCRIPTION
I needed to poll the state of a job.
Currently you only have `ScrapydClient.job`, it's a bit nicer to do it like this, I think.